### PR TITLE
fix: Cannot redefine property: _req_ctx

### DIFF
--- a/src/factory/common/managedResolverFactory.ts
+++ b/src/factory/common/managedResolverFactory.ts
@@ -390,6 +390,15 @@ export class ManagedResolverFactory {
 
     const inst = definition.creator.doConstruct(Clzz, constructorArgs);
 
+    // binding ctx object
+    if (definition.isRequestScope() && definition.constructor.name === 'ObjectDefinition') {
+      Object.defineProperty(inst, REQUEST_OBJ_CTX_KEY, {
+        value: this.context.get(REQUEST_CTX_KEY),
+        writable: false,
+        enumerable: false,
+      });
+    }
+
     if (definition.properties) {
       const keys = definition.properties.keys();
       for (const key of keys) {
@@ -471,7 +480,7 @@ export class ManagedResolverFactory {
     }
 
     // binding ctx object
-    if (definition.isRequestScope()) {
+    if (definition.isRequestScope() && definition.constructor.name === 'ObjectDefinition') {
       Object.defineProperty(inst, REQUEST_OBJ_CTX_KEY, {
         value: this.context.get(REQUEST_CTX_KEY),
         writable: false,

--- a/test/unit/requestContainer.test.ts
+++ b/test/unit/requestContainer.test.ts
@@ -118,7 +118,7 @@ describe('/test/unit/requestContainer.test.ts', () => {
     expect(tracer1.getData()).to.equal(tracer2.getData());
   });
 
-  it.only('should get ctx from object in requestContainer', async () => {
+  it('should get ctx from object in requestContainer', async () => {
     const appCtx = new Container();
     appCtx.bind(DataCollector);
     appCtx.bind(ChildTracer);


### PR DESCRIPTION
通过 wrapperProvide 提供的 function 返回的对象不需要 req ctx